### PR TITLE
Pi 3B and 4B fix for PulseAudio

### DIFF
--- a/snapcast/docs/2_install_pulseaudio.md
+++ b/snapcast/docs/2_install_pulseaudio.md
@@ -76,11 +76,17 @@ Run `pactl list sinks` and scroll to the bottom and notice your Active Port is p
 ```sh
 pactl set-sink-port 1 "analog-output-headphones"
 ```
+Please note that if you are setting this up on a Raspberry Pi 3B or 4B, you need an additional step at this point to make it route the audio through the 2mic hat (and likely the 4mic one as well). Run the following command to do this.
+
+```sh
+pactl set-default-sink alsa_output.platform-soc_sound.stereo-fallback
+```
 
 13. Test and make sure you can hear the wav file:
 ```sh
 paplay /usr/share/sounds/alsa/Front_Center.wav
 ```
+Note that if you have a RAspbery Pi 3B or 4B, this may or may not seem to work, but it will output on the hat as intended.
 
 14. Modify PulseAudio to duck the music volume when you or the voice assistant are speaking:
 ```sh

--- a/snapcast/docs/2_install_pulseaudio.md
+++ b/snapcast/docs/2_install_pulseaudio.md
@@ -86,7 +86,7 @@ pactl set-default-sink alsa_output.platform-soc_sound.stereo-fallback
 ```sh
 paplay /usr/share/sounds/alsa/Front_Center.wav
 ```
-Note that if you have a RAspbery Pi 3B or 4B, this may or may not seem to work, but it will output on the hat as intended.
+Note that if you have a Raspbery Pi 3B or 4B, this may or may not seem to work, but it will output on the hat as intended.
 
 14. Modify PulseAudio to duck the music volume when you or the voice assistant are speaking:
 ```sh


### PR DESCRIPTION
I've added instructions that should enable both the 2mic Pi Hat (tested) and 4mic Pit Hat to work if mounted on a Raspberry Pi 3b or 4B. I've also noted that the audio test may not produce output, but audio will still play through the hat anyway.