### PR TITLE
Docs: use dynamic username when possible

### DIFF
--- a/ESPresense/docs/1_install_espresense.md
+++ b/ESPresense/docs/1_install_espresense.md
@@ -13,7 +13,7 @@
 
 6. In the left-hand navigation click on "Devices" then click the blue "Enroll" button. Follow the [Apple Watch enrollment steps on the ESPresense Website](https://espresense.com/beacons/apple#apple-watch-using-bluetooth-terminal-app) to enroll your Apple watch (temporarily requires iOS and Watch app to be installed).
 
-7. Edit HomeAssistant's `configuration.yaml` to add your Apple Watch as a sensor you want to track in Home Assistant.
+7. Edit Home Assistant's `configuration.yaml` to add your Apple Watch as a sensor you want to track in Home Assistant.
 
 ```yaml
 sensor:

--- a/README.md
+++ b/README.md
@@ -4,21 +4,25 @@ This repository is dedicated to sharing tutorials that enhance Home Assistant's 
 
 ## Enhancement 1: Extended OpenAI Conversation Integration
 
-Elevate Home Assistant's voice capabilities by integrating a Large Language Model (LLM) to the conversation agent.  The AI can run locally within your home, or you can pay for OpenAI's cloud-based ChatGPT API. This enhancement helps your voice assistant feel natural while gaining advanced control of your home.
+Elevate Home Assistant's voice capabilities by integrating a Large Language Model (LLM) to the conversation agent. The AI can run locally within your home, or you can pay for OpenAI's cloud-based ChatGPT API. This enhancement helps your voice assistant feel natural while gaining advanced control of your home.
 
 **Voice Command Examples:**
+
 - "Hey Jarvis, turn off the lights, lock the doors, and check if my kids are asleep."
 - "Hey Jarvis, who is Bruce Wayne?"
 
 **Prerequisite Hardware/Software:**
+
 - [Wyoming Voice Satellite project](https://github.com/rhasspy/wyoming-satellite)
 
 **Additional Software/Configurations Required:**
+
 - [Extended OpenAI Conversation](https://github.com/jekalmin/extended_openai_conversation)
 - [Recommended LLM Prompt](https://github.com/FutureProofHomes/wyoming-enhancements/blob/main/extended_openai_conversation/recommended_prompt.txt)
 - [LocalAI](https://localai.io/) (Optional for local LLM)
 
 **Documentation & Tutorials:**
+
 - [Watch the video tutorial](https://www.youtube.com/watch?v=pAKqKTkx5X4)
 - [Written Tutorial](https://github.com/rhasspy/wyoming-satellite)
 
@@ -27,12 +31,15 @@ Elevate Home Assistant's voice capabilities by integrating a Large Language Mode
 Enhance the capabilities of your Wyoming Voice Assistants to unlock multi-room music streaming, akin to Sonos. Enjoy seamless playback of your local music collection, Spotify, Tidal, and more through the speakers connected to your Wyoming Satellites. The system intelligently lowers the music volume when you or the voice assistant are speaking.
 
 **Voice Command Examples:**
+
 - "Hey Jarvis, play Michael Jackson in the loft."
 
 **Prerequisite Hardware/Software:**
+
 - [Wyoming Voice Satellite project](https://github.com/rhasspy/wyoming-satellite)
 
 **Additional Software/Configurations Required:**
+
 - [Extended OpenAI Conversation](https://github.com/jekalmin/extended_openai_conversation)
 - [Snapcast Server](https://github.com/Art-Ev/addon-snapserver)
 - [Snapcast Client](https://github.com/badaix/snapcast)
@@ -40,62 +47,71 @@ Enhance the capabilities of your Wyoming Voice Assistants to unlock multi-room m
 - [BETA Music Assistant](https://github.com/music-assistant/hass-music-assistant)
 
 **Documentation & Tutorials:**
+
 - [Watch the video tutorial](https://youtu.be/kS0agn13hhU)
 - [Written tutorial](https://github.com/FutureProofHomes/wyoming-enhancements/tree/master/snapcast/docs)
 
-
 ## Enhancement 3.1: Bluetooth Presence Detection by Installing Room Assistant on the Wyoming Satellite
 
-Don't have ESP32 hardware but still want to enhance the capability of your Wyoming Voice Satellite so that it can track nearby bluetooth devices (like iPhones, Watches, Androids, etc..)?  Consider installing Room Assistant directly on the Wyoming Satellite Raspberry Pi.
+Don't have ESP32 hardware but still want to enhance the capability of your Wyoming Voice Satellite so that it can track nearby bluetooth devices (like iPhones, Watches, Androids, etc..)? Consider installing Room Assistant directly on the Wyoming Satellite Raspberry Pi.
 
 **Voice Command Examples:**
+
 - "Hey Jarvis, which room is my wife in?"
 
 **Prerequisite Hardware/Software:**
+
 - [Wyoming Voice Satellite project](https://github.com/rhasspy/wyoming-satellite)
 
 **Additional Software/Configurations Required:**
+
 - [Room Assistant](https://www.room-assistant.io/guide/quickstart-pi.html#installing-room-assistant)
 - [MQTT Misquitto Broker](https://www.home-assistant.io/integrations/mqtt/)
 
 **Pros & Cons**
-- Pros: 
-    - No ESP32 required.  Runs directly on the Wyoming Satellite Raspberry Pi
-    - Works nicely with other ESPresense because Room Assistant also supports [MQTT_Room](https://www.room-assistant.io/integrations/home-assistant.html#settings)
-- Cons: 
-    - Cannot track Apple Watches via [Bluetooth Low Energy](https://www.room-assistant.io/integrations/bluetooth-low-energy.html#requirements) and will therefore have slower detection times and impact your watch's battery life.
-    - Can impact the Raspberry Pi's wifi connection when handling heavy bluetooth throughput.
-    - Depending in the device, Room Assistant may require you to install a companion app on your mobile device for ideal tracking.
-    - Room Assistant codebase has not been well maintained for a few years now.
+
+- Pros:
+  - No ESP32 required. Runs directly on the Wyoming Satellite Raspberry Pi
+  - Works nicely with other ESPresense because Room Assistant also supports [MQTT_Room](https://www.room-assistant.io/integrations/home-assistant.html#settings)
+- Cons:
+  - Cannot track Apple Watches via [Bluetooth Low Energy](https://www.room-assistant.io/integrations/bluetooth-low-energy.html#requirements) and will therefore have slower detection times and impact your watch's battery life.
+  - Can impact the Raspberry Pi's WiFi connection when handling heavy bluetooth throughput.
+  - Depending in the device, Room Assistant may require you to install a companion app on your mobile device for ideal tracking.
+  - Room Assistant codebase has not been well maintained for a few years now.
 
 **Documentation & Tutorials:**
+
 - [Video Tutorial](https://www.youtube.com/watch?v=R1kxuB4pi9k)
 - [Written tutorial](https://github.com/FutureProofHomes/wyoming-enhancements/blob/master/Room%20Assistant/docs/1_install_room_assistant.md)
 
+## Enhancement 3.2: Bluetooth Presence Detection by plugging an ESP32 w/ ESPresense into the Wyoming Satellite
 
-## Enhancement 3.2: Bluetooth Presence Detection by plugging an ESP32 w/ ESPresense into the Wyoming Satellite.
-
-Have an ESP32 lying around? Install ESPresense on it then plug it in to the Wyoming Voice Satellite's spare USB port like a dongle.  Enjoy the convience of a single power cable and two products that almost/kinda feel like one.
+Have an ESP32 lying around? Install ESPresense on it then plug it in to the Wyoming Voice Satellite's spare USB port like a dongle. Enjoy the convenience of a single power cable and two products that almost/kinda feel like one.
 
 **Voice Command Examples:**
+
 - "Hey Jarvis, make the music follow me around the home."
 
 **Prerequisite Hardware/Software:**
+
 - [Wyoming Voice Satellite project](https://github.com/rhasspy/wyoming-satellite)
 - [ESP32 Base Station](https://espresense.com/base-stations)
 
 **Additional Software/Configurations Required:**
-- [ESPresense](https://espresense.com/) 
+
+- [ESPresense](https://espresense.com/)
 - [MQTT Misquitto Broker](https://www.home-assistant.io/integrations/mqtt/)
 
 **Pros & Cons**
-- Pros: 
-    - Fast detection times and very configurable
-    - Bluetooth Low Energy works with Apple Devices 
-    - Very active project and codebase
-- Cons: 
-    - Requires extra ESP32 hardware and doesn't run directly on the Wyoming Satellite :(
+
+- Pros:
+  - Fast detection times and very configurable
+  - Bluetooth Low Energy works with Apple Devices
+  - Very active project and codebase
+- Cons:
+  - Requires extra ESP32 hardware and doesn't run directly on the Wyoming Satellite :(
 
 **Documentation & Tutorials:**
+
 - [Video Tutorial](https://www.youtube.com/watch?v=R1kxuB4pi9k)
 - [Written tutorial](https://github.com/FutureProofHomes/wyoming-enhancements/blob/master/ESPresense/docs/1_install_espresense.md)

--- a/snapcast/docs/1_install_snapserver_addons.md
+++ b/snapcast/docs/1_install_snapserver_addons.md
@@ -6,6 +6,7 @@
 
 3. Head to the add-on's Info tab and enable "Start on boot," "Watchdog," and "Auto update." Click Start.
 
-4. Check the add-on's Log tab to ensure the Snapserver started without errors.
+4. Check the add-on's Log tab to ensure the SnapServer started without errors.
 
 5. Installation complete! Proceed to the next tutorial file.
+

--- a/snapcast/docs/2_install_pulseaudio.md
+++ b/snapcast/docs/2_install_pulseaudio.md
@@ -1,48 +1,56 @@
 ## Install PulseAudio On Your Wyoming Voice Satellite
 
 1. Connect to your Pi over SSH using the username/password you configured during flashing:
+
 ```sh
 ssh <your_username>@<pi_IP_address>
 ```
 
 2. Disable/Stop the entire Wyoming stack temporarily:
+
 ```sh
 sudo systemctl disable --now wyoming-satellite.service
 ```
+
 ```sh
 sudo systemctl stop wyoming-openwakeword.service 2mic_leds.service
 ```
 
 3. Install PulseAudio drivers and necessary utilities:
- ```sh
+
+```sh
 sudo apt-get update
 sudo apt-get install \
-    pulseaudio \
-    pulseaudio-utils
+   pulseaudio \
+   pulseaudio-utils
 ```
 
 4. Reboot your Pi:
- ```sh
+
+```sh
 sudo reboot -h now
 ```
 
-5. SSH back in to your Pi.  (See step 1.)
+5. SSH back in to your Pi (See step 1).
 
-6. Ensure PulseAudio is runnining in "system-wide mode".  Per the [official instructions](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/) we first need to stop some existing services to be safe:
- ```sh
+6. Ensure PulseAudio is running in "system-wide mode". Per the [official instructions](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/) we first need to stop some existing services to be safe:
+
+```sh
 sudo systemctl --global disable pulseaudio.service pulseaudio.socket
 ```
 
 7. It is also advisable to set `autospawn = no` in `/etc/pulse/client.conf`:
+
 ```sh
 sudo nano /etc/pulse/client.conf
 ```
 
-
 8. Create our new `PulseAudio.service`:
+
 ```sh
 sudo systemctl edit --force --full pulseaudio.service
 ```
+
 ```sh
 [Unit]
 Description=PulseAudio system server
@@ -55,27 +63,32 @@ ExecStart=pulseaudio --daemonize=no --system --realtime --log-target=journal
 WantedBy=multi-user.target
 ```
 
-9. Start our new `PulseAudio.service`.  This will require you to type in your password a couple times.
- ```sh
- systemctl --system enable pulseaudio.service
- ```
- ```sh
- systemctl --system start pulseaudio.service
- ```
+9. Start our new `PulseAudio.service`. This will require you to type in your password a couple times.
 
-10. Ensure all users needing access to PulseAudio are in the `pulse-access` group:
 ```sh
-sudo sed -i '/^pulse-access:/ s/$/root,pi,snapclient,<your_username_here>/' /etc/group
+systemctl --system enable pulseaudio.service
 ```
 
-11. Reboot your Pi: (see step 4)
+```sh
+systemctl --system start pulseaudio.service
+```
+
+10. Ensure all users needing access to PulseAudio are in the `pulse-access` group:
+
+```sh
+sudo sed -i '/^pulse-access:/ s/$/root,pi,snapclient,$USER/' /etc/group
+```
+
+11. Reboot your Pi (see step 4):
 
 12. (OPTIONAL) If plugging speakers into the headphone jack, set the correct PulseAudio Sync Port:
 
-Run `pactl list sinks` and scroll to the bottom and notice your Active Port is probably "analog-output-speaker".  Run the command below to output audio through the 3.5mm headphone jack.
+Run `pactl list sinks` and scroll to the bottom and notice your Active Port is probably "analog-output-speaker". Run the command below to output audio through the 3.5mm headphone jack.
+
 ```sh
 pactl set-sink-port 1 "analog-output-headphones"
 ```
+
 Please note that if you are setting this up on a Raspberry Pi 3B or 4B, you need an additional step at this point to make it route the audio through the 2mic hat (and likely the 4mic one as well). Run the following command to do this.
 
 ```sh
@@ -83,22 +96,26 @@ pactl set-default-sink alsa_output.platform-soc_sound.stereo-fallback
 ```
 
 13. Test and make sure you can hear the wav file:
+
 ```sh
 paplay /usr/share/sounds/alsa/Front_Center.wav
 ```
-Note that if you have a Raspbery Pi 3B or 4B, this may or may not seem to work, but it will output on the hat as intended.
+
+Note that if you have a Raspberry Pi 3B or 4B, this may or may not seem to work, but it will output on the hat as intended.
 
 14. Modify PulseAudio to duck the music volume when you or the voice assistant are speaking:
+
 ```sh
 sudo nano /etc/pulse/system.pa
 ```
 
 Add the module below to the bottom of the file and save.
+
 ```sh
 ### Enable Volume Ducking
 load-module module-role-ducking trigger_roles=announce,phone,notification,event ducking_roles=any_role volume=33%
 ```
 
-15. Reboot your Pi: (see step 4)
+15. Reboot your Pi (see step 4):
 
-16. Done! Move to next tutorial file.
+16. Done! Move to the next tutorial file.

--- a/snapcast/docs/3_install_snapclient.md
+++ b/snapcast/docs/3_install_snapclient.md
@@ -1,33 +1,37 @@
 ## Install the SnapClient On Your Wyoming Voice Satellite
 
 1. Connect to your Pi over SSH using the username/password you configured during flashing:
+
 ```sh
 ssh <your_username>@<pi_IP_address>`
 ```
 
 2. Make sure you are in your home directory
+
 ```sh
 cd ~
 ```
 
 3. Clone this wyoming-enhancements repository to your Pi so you can use the scripts.
+
 ```sh
 git clone https://github.com/FutureProofHomes/wyoming-enhancements.git
 ```
 
-4. Follow [the Snapclient developer's install steps](https://github.com/badaix/snapcast/blob/develop/doc/install.md#debian) to download the SnapClient into our new enhancements directory:
+4. Follow [the SnapClient developer's install steps](https://github.com/badaix/snapcast/blob/develop/doc/install.md#debian) to download the SnapClient into our new enhancements directory:
+
 ```sh
 cd wyoming-enhancements/snapcast/
 wget https://github.com/badaix/snapcast/releases/download/v0.27.0/snapclient_0.27.0-1_armhf.deb
-```
-```sh
 sudo apt install ./snapclient_0.27.0-1_armhf.deb
 ```
 
 5. Get the IP address of your SnapServer (typically the same IP as your Home Assistant instance) and let's modify the SnapClient's options so it always boots with correct settings.
+
 ```sh
 sudo nano /etc/default/snapclient
 ```
+
 ```sh
 # Start the client, used only by the init.d script
 START_SNAPCLIENT=true
@@ -39,11 +43,13 @@ SNAPCLIENT_OPTS="-h 192.168.xx.xx --player pulse:property=media.role=music --sam
 ```
 
 6. Let's modify our Snapcast service to it starts AFTER PulseAudio has already started:
+
 ```sh
 sudo systemctl edit --force --full snapclient.service
 ```
-    
-Find the `After=....` line and add `pulseaudio.service`.  Your final modified service should look similar to the below:
+
+Find the `After=....` line and add `pulseaudio.service`. Your final modified service should look similar to the below:
+
 ```sh
 [Unit]
 Description=Snapcast client
@@ -63,15 +69,17 @@ WantedBy=multi-user.target
 ```
 
 7. Reboot your Pi:
+
 ```sh
 sudo reboot -h now
 ```
 
-8. SSH back in to your Pi.  (See step 1)
+8. SSH back in to your Pi (See step 1).
 
-9. Check to make sure both PulseAudio and your Snapclient are running as expected.  You should see green lights next to both services:
+9. Check to make sure both PulseAudio and your SnapClient are running as expected. You should see green lights next to both services:
+
 ```sh
 sudo systemctl status pulseaudio.service snapclient.service
 ```
 
-10. Done! Move to next tutorial file.
+10. Done! Move to the next tutorial file.

--- a/snapcast/docs/4_modify_wyoming_satellite.md
+++ b/snapcast/docs/4_modify_wyoming_satellite.md
@@ -1,56 +1,67 @@
-## Create a Modified `Wyoming-Satellite.service` That Usse PulseAudio
+## Create a Modified `Wyoming-Satellite.service` That Uses PulseAudio
 
 1. Connect to your Pi over SSH using the username/password you configured during flashing:
+
 ```sh
 ssh <your_username>@<pi_IP_address>
 ```
 
-2. Make a copy of your exisitng `wyoming-satellite.service` and rename that copy to `enhanced-wyoming-satellite.service`:
+2. Make a copy of your existing `wyoming-satellite.service` and rename that copy to `enhanced-wyoming-satellite.service`:
+
 ```sh
 sudo cp /etc/systemd/system/wyoming-satellite.service /etc/systemd/system/enhanced-wyoming-satellite.service
 ```
 
-3. Modify our new `enhanced-wyoming-satellite.service` to leverage pulseAudio and our volume ducking capabilities.
+3. Modify our new `enhanced-wyoming-satellite.service` to leverage PulseAudio and our volume ducking capabilities.
+
 ```sh
 sudo systemctl edit --force --full enhanced-wyoming-satellite.service
 ```
 
 Add `Requires=pulseaudio.service` in the `[Unit]` section
+
 ```sh
 Requires=pulseaudio.service
 ```
 
 Update `--mic-command` to use PulseAudio's `parecord` command:
+
 ```sh
 --mic-command 'parecord --property=media.role=phone --rate=16000 --channels=1 --format=s16le --raw --latency-msec 10' \
 ```
 
 Update `--send-command` to use PulseAudio's `paplay` command:
+
 ```sh
 --snd-command 'paplay --property=media.role=announce --rate=44100 --channels=1 --format=s16le --raw --latency-msec 10' \
 ```
 
 Update `--send-command-rate` to to match our `44100` sample rate we've been using`:
+
 ```sh
 --snd-command-rate 44100 \
 ```
 
-Add `--detection-command` so that we duck our volume when necessary.  BE SURE TO ADD YOUR USERNAME!
+Add `--detection-command` so that we duck our volume when necessary.
+
 ```sh
---detection-command '/home/<your_username>/wyoming-enhancements/snapcast/scripts/awake.sh' \
+--detection-command '/home/%u/wyoming-enhancements/snapcast/scripts/awake.sh' \
 ```
 
-Add `--tts-stop-command` so that we turn the volume back up after the interaction is complete.  BE SURE TO ADD YOUR USERNAME!
+Add `--tts-stop-command` so that we turn the volume back up after the interaction is complete.
+
 ```sh
---tts-stop-command '/home/<your_username>/wyoming-enhancements/snapcast/scripts/done.sh' \
+--tts-stop-command '/home/%u/wyoming-enhancements/snapcast/scripts/done.sh' \
 ```
 
-Add `--error-command` so that we turn the volume back up after an error.  BE SURE TO ADD YOUR USERNAME!
+Add `--error-command` so that we turn the volume back up after an error.
+
 ```sh
---error-command '/home/<your_username>/wyoming-enhancements/snapcast/scripts/done.sh' \
+--error-command '/home/%u/wyoming-enhancements/snapcast/scripts/done.sh' \
 ```
 
-5. Your resulting `enhanced-wyoming-satellite.service` should resemble the below.  Be sure to change `loftsatellite` to your username.
+5. Your resulting `enhanced-wyoming-satellite.service` should resemble the below.
+
 ```sh
 [Unit]
 Description=Enhanced Wyoming Satellite
@@ -62,7 +73,7 @@ Requires=pulseaudio.service
 
 [Service]
 Type=simple
-ExecStart=/home/loftsatellite/wyoming-satellite/script/run \
+ExecStart=/home/%u/wyoming-satellite/script/run \
     --name 'Loft Satellite' \
     --uri 'tcp://0.0.0.0:10700' \
     --mic-command 'parecord --property=media.role=phone --rate=16000 --channels=1 --format=s16le --raw --latency-msec 10' \
@@ -74,26 +85,29 @@ ExecStart=/home/loftsatellite/wyoming-satellite/script/run \
     --wake-uri 'tcp://127.0.0.1:10400' \
     --wake-word-name 'hey_jarvis' \
     --event-uri 'tcp://127.0.0.1:10500' \
-    --detection-command '/home/loftsatellite/wyoming-enhancements/snapcast/scripts/awake.sh' \
-    --tts-stop-command '/home/loftsatellite/wyoming-enhancements/snapcast/scripts/done.sh' \
-    --error-command '/home/<your_username>/wyoming-enhancements/snapcast/scripts/done.sh' \
+    --detection-command '/home/%u/wyoming-enhancements/snapcast/scripts/awake.sh' \
+    --tts-stop-command '/home/%u/wyoming-enhancements/snapcast/scripts/done.sh' \
+    --error-command '/home/%u/wyoming-enhancements/snapcast/scripts/done.sh' \
     --awake-wav sounds/awake.wav \
     --done-wav sounds/done.wav
-WorkingDirectory=/home/loftsatellite/wyoming-satellite
+WorkingDirectory=/home/%u/wyoming-satellite
 Restart=always
 RestartSec=1
 
 [Install]
 WantedBy=default.target
 ```
+
 6. Start our newly created `enhanced-wyoming-satellite.service` service:
+
 ```sh
 sudo systemctl enable --now enhanced-wyoming-satellite.service
 ```
 
 7. Make sure all 5 services are running on your pi with green lights:
+
 ```sh
 sudo systemctl status enhanced-wyoming-satellite.service wyoming-openwakeword.service 2mic_leds.service pulseaudio.service snapclient.service
 ```
 
-8. Done! Move to next tutorial file.
+8. Done! Move to the next tutorial file.

--- a/snapcast/docs/5_setup_Music_Assistant_with_SnapCast_support.md
+++ b/snapcast/docs/5_setup_Music_Assistant_with_SnapCast_support.md
@@ -1,13 +1,13 @@
 ## Install the Music Assistant Add-On
 
-1. [Follow the steps documented in the Music Assistant Github Repo](https://github.com/music-assistant/hass-music-assistant?tab=readme-ov-file#installation-of-the-home-assistant-beta-integration) to install the latest BETA version of Music Assistant. 
+1. [Follow the steps documented in the Music Assistant Github Repo](https://github.com/music-assistant/hass-music-assistant?tab=readme-ov-file#installation-of-the-home-assistant-beta-integration) to install the latest BETA version of Music Assistant.
 
-2. When installing be sure you select our `Extended Open AI Conversation` agent.  Also, expose the players to Assist.
+2. When installing be sure you select our `Extended Open AI Conversation` agent. Also, expose the players to Assist.
 
-3. In Music Assistant settings, add your favorite music provider.  I use Spotify.
+3. In Music Assistant settings, add your favorite music provider. I use Spotify.
 
-4. In Music Assistant settings, click "Add Player Provider" and select Snapcast.  Keep settings default.
+4. In Music Assistant settings, click "Add Player Provider" and select Snapcast. Keep settings default.
 
 5. You should see now your Wyoming Satellite(s) as a Snapcast player in Music Assistant.
 
-6. Done! Move to next tutorial file.
+6. Done! Move to the next tutorial file.

--- a/snapcast/docs/6_enable_extended_openai_conversation_play_music.md
+++ b/snapcast/docs/6_enable_extended_openai_conversation_play_music.md
@@ -1,6 +1,7 @@
-## Enable the LLM to `Play_Music` via Music Assistant.
+## Enable the LLM to `Play_Music` via Music Assistant
 
 1. Copy my `play_music` script to your Home Assistant scripts.
+
 ```
 alias: Play Music
 sequence:
@@ -26,7 +27,8 @@ sequence:
 mode: single
 ```
 
-2. (OPTIONAL, USE AT YOUR OWN RISK) Below is a slighly modified `play_music` script that tries to automatically play music back on the voice assistant you last spoke on.  This allows you to say "Play Nirvana" instead of "Play Nirvana in the loft".  There are many other ways to implement a solution, this is just an experiment.
+2. (OPTIONAL, USE AT YOUR OWN RISK) Below is a slightly modified `play_music` script that tries to automatically play music back on the voice assistant you last spoke on. This allows you to say "Play Nirvana" instead of "Play Nirvana in the loft". There are many other ways to implement a solution, this is just an experiment.
+
 ```
 alias: Play Music
 sequence:
@@ -63,6 +65,7 @@ mode: single
 ```
 
 3. Add my spec to your Extended OpenAI Conversation functions so that the LLM can execute your `play_music` script:
+
 ```
 - spec:
     name: play_music
@@ -87,6 +90,6 @@ mode: single
         mass_media_player: '{{mass_media_player}}'
 ```
 
-4.  All done!  Now ask your voice assistant to "Play [artist_name, genre_of_music, or_album] in my [room_name]"
+4. All done! Now ask your voice assistant to "Play [artist_name, genre_of_music, or_album] in my [room_name]"
 
-NOTE: I recognize there are many more music related scripts to be desired. I invite others to make PRs or share their HA scripts/Extended OpenAI Conversation specs.  Let's also be sure and share our working scripts with the original developers for their documentation.
+NOTE: I recognize there are many more music related scripts to be desired. I invite others to make PRs or share their HA scripts/Extended OpenAI Conversation specs. Let's also be sure and share our working scripts with the original developers for their documentation.

--- a/snapcast/docs/optional_1_homeassistant_sensors_and_controls.md
+++ b/snapcast/docs/optional_1_homeassistant_sensors_and_controls.md
@@ -1,14 +1,15 @@
 # [OPTIONAL] Integrate Satellite PulseAudio into HomeAssistnat
 
 ## Background
+
 Currently, there are no known integrations for controlling remote PulseAudio servers.
 
-The following setup will create `shell_command` services allowing for control from HomeAssistant. 
+The following setup will create `shell_command` services allowing for control from Home Assistant.
 
 These services can be used to integrate controls on dashboards, used in automations, etc.
 
-
 Basic Volume and Mute controls:
+
 - Set volume to a specified %
 - Increase/Decrease volume by specific %
 - Mute/Unmute/Toggle Mute
@@ -16,10 +17,12 @@ Basic Volume and Mute controls:
 ---
 
 ## Services (shell_command)
-The services are built on `shell_command` which utilizes ssh commands from the HomeAssistant instance to the satellites.  
-The community has provided excellent guides on setting up passwordless ssh connections from your HomeAssistant instance which is a prerequisite to this setup.
+
+The services are built on `shell_command` which utilizes ssh commands from the Home Assistant instance to the satellites.  
+The community has provided excellent guides on setting up password-less SSH connections from your Home Assistant instance which is a prerequisite to this setup.
 
 Add the following `shell_command` definitions to your configuration:
+
 ```
 shell_command:
   pa_volume_set: "ssh -i /config/.ssh/id_rsa -o UserKnownHostsFile=/config/.ssh/known_hosts {{ ssh_user_at_host }} pamixer --set-volume {{ volume_percent }}"
@@ -36,6 +39,7 @@ The variable `{{ ssh_user_at_host }}` should be set in the payload to address th
 Examples:
 
 Increase volume by 10%:
+
 ```
 - service: shell_command.pa_volume_increase
             metadata: {}
@@ -45,6 +49,7 @@ Increase volume by 10%:
 ```
 
 Set the volume to a specified percentage - take the value from an `input_number` helper which can be a slider on your dashboard:
+
 ```
 - service: shell_command.pa_volume_set
             metadata: {}
@@ -53,15 +58,15 @@ Set the volume to a specified percentage - take the value from an `input_number`
               volume_percent: "{{ states('input_number.volume_slider')|int }}"
 ```
 
-
 ---
 
 ## Switches and Sensors
 
-We can create entities in HomeAssistant to represent our PulseAudio server state on the satellite.  You can create a corresponding `switch` and `sensor` entity for each.
+We can create entities in Home Assistant to represent our PulseAudio server state on the satellite. You can create a corresponding `switch` and `sensor` entity for each.
 For this function, we use the `command_line` integration.
 
 In your configuration, add:
+
 ```
 command_line:
   - switch:
@@ -106,9 +111,8 @@ For instance, you can add a volume slider and a mute toggle button.
 
 The volume slider can be implemented with the assistance of an `input_number` helper and a small automation to sync the state.
 
-This sample automation is basic but functional.  It is bi-directional - meaning that the changing the slider will change the volume on the satellite.
-Inversely, the slider will update on the HomeAssistant side if the volume is changed from the satellite.
-
+This sample automation is basic but functional. It is bi-directional - meaning that the changing the slider will change the volume on the satellite.
+Inversely, the slider will update on the Home Assistant side if the volume is changed from the satellite.
 
 ```
 alias: "[controller] Set PA volume from Input Slider"

--- a/snapcast/scripts/awake.sh
+++ b/snapcast/scripts/awake.sh
@@ -2,7 +2,7 @@
 echo $(date) [awake.sh] ...Starting awake.sh script
 
 ### Insert any commands that you would like to call for performing external actions.
-### This example will call a webhook on the HomeAssistant server which sends a remote control command to toggle mute on a sound bar.
+### This example will call a webhook on the Home Assistant server which sends a remote control command to toggle mute on a sound bar.
 
 #echo $(date) [awake.sh] ...Sending mute to living room tv 
 #curl -X POST -H "Content-Type: application/json" -d '{"remote":"remote.living_room_hub","device":"JBL Sound Bar","command":"Mute"}' https://<HA server address>:8123/api/webhook/<WEBHOOK>  > /dev/null 2>&1 

--- a/snapcast/scripts/done.sh
+++ b/snapcast/scripts/done.sh
@@ -17,7 +17,7 @@ echo $(date) [done.sh] ...Killing 'silence' pulseaudio client
 sudo kill $(pactl list clients | awk '/application.name = "silence"/,/^$/' | awk -F' = ' '/application.process.id/ {print $2}' | sed 's/"//g')
 
 ### Insert any commands that you would like to call for performing external actions.
-### This example will call a webhook on the HomeAssistant server which sends a remote control command to toggle mute on a sound bar.
+### This example will call a webhook on the Home Assistant server which sends a remote control command to toggle mute on a sound bar.
 
 #echo $(date) [done.sh] ...Sending mute to living room tv 
 #curl -X POST -H "Content-Type: application/json" -d '{"remote":"remote.living_room_hub","device":"JBL Sound Bar","command":"Mute"}' https://<HA server address>:8123/api/webhook/<WEBHOOK>  > /dev/null 2>&1 


### PR DESCRIPTION
Replaced placeholders for username with Unix' `$USER` or systemd's `%u`. Formatted using Prettier. Also fixed some typos.

Ref:
- https://www.man7.org/linux/man-pages/man5/systemd.unit.5.html

Note: the GitHub diff compare shows line changes. Please review locally using Git's `--ignore-all-space`.