### PR TITLE
fix indentation in play_music script for copy pasting

### DIFF
--- a/snapcast/docs/6_enable_extended_openai_conversation_play_music.md
+++ b/snapcast/docs/6_enable_extended_openai_conversation_play_music.md
@@ -19,7 +19,7 @@ sequence:
      entity_id: "{{mass_media_player}}"
    data: {}
  - service: mass.play_media
-    data:
+   data:
       media_id: "{{query_response.playlists[0].uri}}"
       entity_id: "{{mass_media_player}}"
       enqueue: replace


### PR DESCRIPTION
I could not save the script that i copy pasted from the docs.
Found an extra space in the first play_music script.