### PR TITLE
Update Snapclient Install for Latest Release

### DIFF
--- a/snapcast/docs/3_install_snapclient.md
+++ b/snapcast/docs/3_install_snapclient.md
@@ -18,10 +18,10 @@ git clone https://github.com/FutureProofHomes/wyoming-enhancements.git
 4. Follow [the Snapclient developer's install steps](https://github.com/badaix/snapcast/blob/develop/doc/install.md#debian) to download the SnapClient into our new enhancements directory:
 ```sh
 cd wyoming-enhancements/snapcast/
-wget https://github.com/badaix/snapcast/releases/download/v0.27.0/snapclient_0.27.0-1_armhf.deb
+wget https://github.com/badaix/snapcast/releases/download/v0.29.0/snapclient_0.29.0-1_armhf_bookworm_with-pulse.deb
 ```
 ```sh
-sudo apt install ./snapclient_0.27.0-1_armhf.deb
+sudo apt install ./snapclient_0.29.0-1_armhf_bookworm_with-pulse.deb
 ```
 
 5. Get the IP address of your SnapServer (typically the same IP as your Home Assistant instance) and let's modify the SnapClient's options so it always boots with correct settings.


### PR DESCRIPTION
This updates the doc with the latest release of Snapclient with Pulse deps that is now required.